### PR TITLE
fix TS6133 ts error

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -66,10 +66,10 @@ export function asyncHelpers(hbs: any) {
   handlebars.template = function (spec: any) {
     spec.main_d =
       (
-        prog: any,
-        props: any,
+        _prog: any,
+        _props: any,
         container: any,
-        depth: any,
+        _depth: any,
         data: any,
         blockParams: any,
         depths: any


### PR DESCRIPTION
This library does not compile if the `noUnusedParameters` config is set to true.

This PR fixes this issue by adding an underscore on the unused parameters so it will pass the strict check.